### PR TITLE
feat(mlflow): bump urllib3 to remediate GHSA-48p4-8xcf-vxj5 and GHSA-pq67-6m6q-mj2v

### DIFF
--- a/mlflow.yaml
+++ b/mlflow.yaml
@@ -71,6 +71,9 @@ pipeline:
       # Upgrade requests to fix GHSA-9hjg-9r4m-mvj7
       pip install --upgrade "requests>=2.32.4"
 
+      # Upgrade urllib3 to fix GHSA-48p4-8xcf-vxj5 and GHSA-pq67-6m6q-mj2v
+      pip install --upgrade "urllib3>=2.5.0"
+
       # Remove pip
       pip uninstall --yes pip
 
@@ -122,6 +125,9 @@ subpackages:
 
           # Upgrade requests to fix GHSA-9hjg-9r4m-mvj7
           pip install --upgrade "requests>=2.32.4"
+
+          # Upgrade urllib3 to fix GHSA-48p4-8xcf-vxj5 and GHSA-pq67-6m6q-mj2v
+          pip install --upgrade "urllib3>=2.5.0"
 
           # Remove pip
           pip uninstall --yes pip
@@ -185,6 +191,9 @@ subpackages:
 
           # Upgrade requests to fix GHSA-9hjg-9r4m-mvj7
           pip install --upgrade "requests>=2.32.4"
+
+          # Upgrade urllib3 to fix GHSA-48p4-8xcf-vxj5 and GHSA-pq67-6m6q-mj2v
+          pip install --upgrade "urllib3>=2.5.0"
 
           # Remove pip
           pip uninstall --yes pip


### PR DESCRIPTION
Signed-off-by: Francesco Bartolini <francesco.bartolini@chainguard.dev>

Bump urllib3 to v2.5.0
